### PR TITLE
feat: employee update logic and response dto

### DIFF
--- a/src/main/java/com/supercoding/hrms/com/exception/CustomMessage.java
+++ b/src/main/java/com/supercoding/hrms/com/exception/CustomMessage.java
@@ -27,6 +27,9 @@ public enum CustomMessage {
     FAIL_EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 이메일의 사용자를 찾을 수 없습니다."),
 
     FAIL_FILE_UPLOAD(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드 중 오류가 발생했습니다."),
+    EMPLOYEE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사원을 찾을 수 없습니다."),
+    DEPARTMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 부서를 찾을 수 없습니다."),
+    GRADE_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 직급을 찾을 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/supercoding/hrms/emp/controller/EmpController.java
+++ b/src/main/java/com/supercoding/hrms/emp/controller/EmpController.java
@@ -1,9 +1,9 @@
 package com.supercoding.hrms.emp.controller;
 
-import com.supercoding.hrms.com.exception.CustomException;
-import com.supercoding.hrms.com.exception.CustomMessage;
+
 import com.supercoding.hrms.emp.dto.request.EmployeeSaveRequestDto;
 import com.supercoding.hrms.emp.dto.request.EmployeeSearchRequestDto;
+import com.supercoding.hrms.emp.dto.request.EmployeeUpdateRequestDto;
 import com.supercoding.hrms.emp.dto.response.*;
 import com.supercoding.hrms.emp.service.EmpService;
 import jakarta.validation.Valid;
@@ -50,10 +50,9 @@ public class EmpController {
         return ResponseEntity.ok("계정이 비활성화되었습니다.");
     }
 
-//    @PatchMapping("/employees/{empId}/unlock")
-//    public ResponseEntity<CustomException> getAccUnlock(@PathVariable Long empId) {
-//        empService.getAccUnlock(empId);
-//        return ResponseEntity.ok(new CustomException(CustomMessage.SUCCESS_ACCOUNT_ENABLE));
-//
-//    }
+    @PatchMapping("/employees/update")
+    public ResponseEntity<EmployeeUpdateResponseDto> updateEmployee(@RequestPart("data") @Valid EmployeeUpdateRequestDto req, @RequestPart(value = "file", required = true) MultipartFile photo) {
+        return ResponseEntity.ok(empService.updateEmployee(req, photo));
+
+    }
 }

--- a/src/main/java/com/supercoding/hrms/emp/dto/request/EmployeeUpdateRequestDto.java
+++ b/src/main/java/com/supercoding/hrms/emp/dto/request/EmployeeUpdateRequestDto.java
@@ -1,0 +1,32 @@
+package com.supercoding.hrms.emp.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class EmployeeUpdateRequestDto {
+    private Long empId;
+
+    @Email(message = "올바른 이메일 형식을 입력해주세요.")
+    @NotBlank(message = "이메일을 입력해주세요.")
+    private String email;
+
+    @NotBlank(message = "이름을 입력해주세요.")
+    private String empNm;
+
+    @NotBlank(message = "생년월일을 입력해주세요.")
+    private String birthDate;
+
+    @NotBlank(message = "전화번호를 입력해주세요.")
+    private String phone;
+
+    @NotBlank(message = "부서를 입력해주세요.")
+    private String deptId;
+
+    @NotBlank(message = "직급을 입력해주세요.")
+    private String gradeId;
+
+    @NotBlank(message = "올바른 접근이 아닙니다.")
+    private String registerId;
+}

--- a/src/main/java/com/supercoding/hrms/emp/dto/response/EmployeeUpdateResponseDto.java
+++ b/src/main/java/com/supercoding/hrms/emp/dto/response/EmployeeUpdateResponseDto.java
@@ -1,0 +1,23 @@
+package com.supercoding.hrms.emp.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EmployeeUpdateResponseDto {
+    private Long empId;
+    private Long empNo;
+    private String email;
+    private String empNm;
+    private String birthDate;
+    private String hireDate;
+    private String phone;
+    private String deptId;
+    private String deptNm;
+    private String gradeId;
+    private String gradeNm;
+    private String photo;
+    private String updateAt;
+    private String upEmpId;
+}

--- a/src/main/java/com/supercoding/hrms/emp/entity/Employee.java
+++ b/src/main/java/com/supercoding/hrms/emp/entity/Employee.java
@@ -2,6 +2,7 @@ package com.supercoding.hrms.emp.entity;
 
 import com.supercoding.hrms.com.entity.Department;
 import com.supercoding.hrms.com.entity.Grade;
+import com.supercoding.hrms.emp.dto.request.EmployeeUpdateRequestDto;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -87,4 +88,39 @@ public class Employee {
     @Column(name= "up_emp_id",nullable = false, length = 4)
     private String upEmpId;
 
+    public void updateEmployeeInfo(EmployeeUpdateRequestDto req) {
+        if (req.getEmail() != null && !req.getEmail().isBlank() && !req.getEmail().equals(this.email)) {
+            this.email = req.getEmail();
+        }
+
+        if (req.getEmpNm() != null && !req.getEmpNm().isBlank() && !req.getEmpNm().equals(this.empNm)) {
+            this.empNm = req.getEmpNm();
+        }
+
+        if (req.getBirthDate() != null && !req.getBirthDate().isBlank() && !req.getBirthDate().equals(this.birthDate)) {
+            this.birthDate = req.getBirthDate();
+        }
+
+        if (req.getPhone() != null && !req.getPhone().isBlank() && !req.getPhone().equals(this.phone)) {
+            this.phone = req.getPhone();
+        }
+
+        if (req.getRegisterId() != null && !req.getRegisterId().isBlank() && !req.getRegisterId().equals(this.upEmpId)) {
+            this.upEmpId = req.getRegisterId();
+        }
+
+        this.updateAt = LocalDate.now();
+    }
+
+    public void updateDepartment(Department department) {
+        this.department = department;
+    }
+
+    public void updateGrade(Grade grade) {
+        this.grade = grade;
+    }
+
+    public void updatePhoto(String photo) {
+        this.photo = photo;
+    }
 }

--- a/src/main/java/com/supercoding/hrms/security/util/JwtTokenProvider.java
+++ b/src/main/java/com/supercoding/hrms/security/util/JwtTokenProvider.java
@@ -15,23 +15,23 @@ public class JwtTokenProvider {
     private final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
 
     public String generateAccessToken(String email) {
-        long expiration_10m = 1000L * 60 * 10;//1000L * 60 * 10;
+        long expiration_30m = 1000L * 60 * 30;
         return Jwts.builder()
                 .setSubject(email)
                 .claim("token_type", "ACCESS")
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + expiration_10m))
+                .setExpiration(new Date(System.currentTimeMillis() + expiration_30m))
                 .signWith(key)
                 .compact();
     }
 
     public String generateRefreshToken(String email) {
-        long expiration_30m = 1000L * 60 * 30; //1000L * 60 * 30;
+        long expiration_7d = 1000L * 60 * 60 * 24 * 7;
         return Jwts.builder()
                 .setSubject(email)
                 .claim("token_type", "REFRESH")
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + expiration_30m))
+                .setExpiration(new Date(System.currentTimeMillis() + expiration_7d))
                 .signWith(key)
                 .compact();
     }


### PR DESCRIPTION
- EmployeeUpdateRequestDto / ResponseDto 추가
- updateEmployeeInfo() 로직 구현 (email, 이름, 생일, 전화번호 변경)
- up_emp_id 자동 갱신 로직 추가
- update_at 최신화(LocalDate.now()) 적용
- 부서/직급 변경 로직 추가
- 사진 업로드 시 S3 저장 적용
- Service @Transactional 적용